### PR TITLE
fixes to align to foreman 1.7-stable

### DIFF
--- a/app/models/concerns/foreman_openscap/arf_report_extensions.rb
+++ b/app/models/concerns/foreman_openscap/arf_report_extensions.rb
@@ -15,7 +15,7 @@ module ForemanOpenscap
     extend ActiveSupport::Concern
     include Taxonomix
     included do
-      has_one :host, :through => :asset, :as => :assetable, :source => :assetable, :source_type => '::Host::Base'
+      has_one :host, :through => :asset, :as => :assetable, :source => :assetable, :source_type => 'Host::Base'
 
       after_save :assign_locations_organizations
 

--- a/app/models/concerns/foreman_openscap/asset_extensions.rb
+++ b/app/models/concerns/foreman_openscap/asset_extensions.rb
@@ -15,11 +15,11 @@ module ForemanOpenscap
     extend ActiveSupport::Concern
     included do
       belongs_to :assetable, :polymorphic => true
-      scope :hosts, where(:assetable_type => '::Host::Base')
+      scope :hosts, where(:assetable_type => 'Host::Base')
     end
 
     def host
-      fetch_asset('::Host::Base')
+      fetch_asset('Host::Base')
     end
 
     private

--- a/app/models/concerns/foreman_openscap/asset_extensions.rb
+++ b/app/models/concerns/foreman_openscap/asset_extensions.rb
@@ -22,6 +22,10 @@ module ForemanOpenscap
       fetch_asset('Host::Base')
     end
 
+    def name
+      assetable.name
+    end
+
     private
     def fetch_asset(type)
       assetable if assetable_type == type

--- a/app/models/concerns/foreman_openscap/host_extensions.rb
+++ b/app/models/concerns/foreman_openscap/host_extensions.rb
@@ -17,7 +17,7 @@ module ForemanOpenscap
     end
 
     def get_asset
-      Scaptimony::Asset.where(:assetable_type => '::Host::Base', :assetable_id => id).first_or_create!
+      Scaptimony::Asset.where(:assetable_type => 'Host::Base', :assetable_id => id).first_or_create!
     end
 
     module ClassMethods

--- a/app/models/concerns/foreman_openscap/policy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/policy_extensions.rb
@@ -24,7 +24,7 @@ module ForemanOpenscap
 
       has_many :hostgroups, :through => :assets, :as => :assetable, :source => :assetable, :source_type => '::Hostgroup'
 
-      validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
+      validates :name, :presence => true, :uniqueness => true, :format => { without: /\s/ }
       validate :ensure_needed_puppetclasses
       validates :weekday, :inclusion => {:in => Date::DAYNAMES.map(&:downcase)}, :if => Proc.new { | policy | policy.step_index > 3 }
       validates :period, :inclusion => {:in => %w[weekly monthly]}, :if => Proc.new { | policy | policy.step_index > 3 }


### PR DESCRIPTION
1. returned to ```'Host::Base'```, instead of ```'::Host::Base'``` - reason for that: with ```'::Host::Base'```, you will get no results for host finders (e.g: ```Host.last.arf_reports```, or ```Host.last.asset```, etc.) which also yields "no compliance reports" for hosts with reports on hosts#index deface

2. ```:no_whitespace => true``` is not merged in foreman-1.7-stable so we can't use it. refactored to ```:format => { without: /\s/ }```, which does the same.