### PR TITLE
[Do not merge] Client sends policy_id instead of policy_name

### DIFF
--- a/app/controllers/api/v2/openscap/arf_reports_controller.rb
+++ b/app/controllers/api/v2/openscap/arf_reports_controller.rb
@@ -21,9 +21,9 @@ module Api
 
         add_puppetmaster_filters :create
 
-        api :POST, "/arf/:cname/:policy_name/:date", N_("Upload an ARF report")
+        api :POST, "/arf/:cname/:policy_id/:date", N_("Upload an ARF report")
         param :cname, :identifier, :required => true
-        param :policy_name, :identifier, :required => true
+        param :policy_id, :identifier, :required => true
         param :date, :identifier, :required => true
 
         def create


### PR DESCRIPTION
Changes from policy_name to policy_id.
Merge with OpenSCAP/scaptimony#16
Merge when client change will be merged.
Fixes #45 