### PR TITLE
Change the look of host status in index

### DIFF
--- a/app/models/concerns/foreman_openscap/arf_report_extensions.rb
+++ b/app/models/concerns/foreman_openscap/arf_report_extensions.rb
@@ -22,7 +22,7 @@ module ForemanOpenscap
       scope :hosts, lambda { includes(:policy, :arf_report_breakdown) }
       scope :latest, lambda { includes(:host, :policy, :arf_report_breakdown).limit(5).order("scaptimony_arf_reports.created_at DESC") }
 
-      scoped_search :in => :asset, :on => :name, :complete_value => :true, :rename => "host"
+      scoped_search :in => :host, :on => :name, :complete_value => :true, :rename => "host"
 
       default_scope {
         with_taxonomy_scope do
@@ -36,6 +36,14 @@ module ForemanOpenscap
         self.locations = [host.location]
         self.organizations = [host.organization]
       end
+    end
+
+    def failed?
+      failed > 0
+    end
+
+    def passed?
+      passed > 0 && !failed?
     end
   end
 end

--- a/app/overrides/hosts/index/host_arf_report.rb
+++ b/app/overrides/hosts/index/host_arf_report.rb
@@ -1,9 +1,5 @@
-Deface::Override.new(:virtual_path  => "hosts/_list",
-                     :name          => "add_comliance_header",
-                     :insert_before => "th:last",
-                     :text          =>  "<th>#{_('Compliance')}</th>")
 
 Deface::Override.new(:virtual_path  => "hosts/_list",
                      :name          => "add_compliance_host_data",
-                     :insert_before => "td:last",
+                     :surround_contents => "td[@class='ellipsis']",
                      :partial       =>  "scaptimony_arf_reports/host_report")

--- a/app/views/scaptimony_arf_reports/_host_report.html.erb
+++ b/app/views/scaptimony_arf_reports/_host_report.html.erb
@@ -1,16 +1,8 @@
-<td>
-  <% if host.arf_reports.any? %>
-  <table>
-    <% host.arf_reports.hosts.each do |report| %>
-      <tr>
-        <td><%= link_to h(report.policy.name), scaptimony_policy_path(report.policy) %></td>
-        <td><%= report_event_column(report.passed, "label-success")  %></td>
-        <td><%= report_event_column(report.failed, "label-danger")  %></td>
-        <td><%= report_event_column(report.othered, "label-info")  %></td>
-      </tr>
-    <% end %>
-  </table>
+<% if host.arf_reports.any? %>
+  <% if host.arf_reports.search_for('failed > 0').blank? %>
+    <%= link_to(report_event_column('O', "label-success"), scaptimony_arf_reports_path(:search => "host=#{host.name}")) %>
   <% else %>
-    <%= _('No compliance report') %>
+    <%= link_to(report_event_column('F', "label-danger"), scaptimony_arf_reports_path(:search => "host=#{host.name}")) %>
   <% end %>
-</td>
+<% end %>
+<%= render_original %>


### PR DESCRIPTION
1. fix the search of host
2. as discussed with @isimluk & @ohadlevy, removed the numerical display of host's compliance and added F / O (fail / Okay) with link to corresponding arf_reports (on the second phase will link to host compliance view - as described in https://github.com/OpenSCAP/foreman_openscap/issues/60)