### PR TITLE
Setting location & organization from host should be by id

### DIFF
--- a/app/models/concerns/foreman_openscap/arf_report_extensions.rb
+++ b/app/models/concerns/foreman_openscap/arf_report_extensions.rb
@@ -33,8 +33,8 @@ module ForemanOpenscap
 
     def assign_locations_organizations
       if host
-        self.location_ids = [host.location] if SETTINGS[:locations_enabled]
-        self.organization_ids = [host.organization] if SETTINGS[:organizations_enabled]
+        self.location_ids = [host.location_id] if SETTINGS[:locations_enabled]
+        self.organization_ids = [host.organization_id] if SETTINGS[:organizations_enabled]
       end
     end
 


### PR DESCRIPTION
An error will occur if trying to set ```location_ids = [host.location]``` should be by taxonomy_id