### PR TITLE
Remove Rakefile from gemspec

### DIFF
--- a/foreman_openscap.gemspec
+++ b/foreman_openscap.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Foreman plug-in for managing security compliance reports"
   s.license     = "GPL-3.0"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "README.md"]
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'deface', '~> 0'


### PR DESCRIPTION
Rakefile has been removed from repository
by 1f7755c721808b4e5f318c829845d50103941f1d

Addressing error while building gem:
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["Rakefile"] are not files