### PR TITLE
Adds validation to scap_content_profile_id

### DIFF
--- a/app/models/concerns/foreman_openscap/policy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/policy_extensions.rb
@@ -31,6 +31,8 @@ module ForemanOpenscap
                 :if => Proc.new { | policy | policy.new_record? ? policy.step_index > 3 && policy.period == 'weekly' : !policy.id.blank? }
       validates :day_of_month, :numericality => {:greater_than => 0, :less_than => 32},
                 :if => Proc.new { | policy | policy.new_record? ? policy.step_index > 3 && policy.period == 'monthly' : !policy.id.blank? }
+
+      validates :scap_content_profile_id, :presence => true
       validate :valid_cron_line
       validate :ensure_period_specification_present
 


### PR DESCRIPTION
If scap_content_profile_id is blank, it will raise an error on the "view guide" page, and may run incorrectly on the client.