### PR TITLE
Enable katello

### DIFF
--- a/lib/foreman_openscap/helper.rb
+++ b/lib/foreman_openscap/helper.rb
@@ -10,8 +10,25 @@
 
 module ForemanOpenscap::Helper
   def self.get_asset(cname, policy_id)
-    asset = Host.find_by_name!(cname).get_asset
+    asset = find_host_by_name_or_uuid(cname).get_asset
     asset.policy_ids += [policy_id]
     asset
+  end
+
+  private
+
+  def self.find_host_by_name_or_uuid(cname)
+    if defined?(Katello::System)
+      host = Host.includes(:content_host).where(:katello_systems => {:uuid => cname}).first
+      host ||= Host.find_by_name(cname)
+    else
+      host = Host.find_by_name(cname)
+    end
+    unless host
+      Rails.logger.error "Could not find Host with name: #{cname}"
+      Rails.logger.error "Please check that Content host is linked to Foreman host" if defined?(Katello::System)
+      raise ActiveRecord::RecordNotFound
+    end
+    host
   end
 end


### PR DESCRIPTION
File ```lib/foreman_openscap/helper.rb``` is now testing if cname is a uuid or a host name.

File ```app/models/concerns/foreman_openscap/policy_extensions.rb``` Adds overrides to the Puppet module to use Katello certificates. This is now ideal, as we take to assumption that the host will also have a content host.

@ohadlevy, @ares, @stbenjam - please review as well. (Thanks!)